### PR TITLE
Using dynamic number of labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-cmake-build-debug/

--- a/kimera_semantics/include/kimera_semantics/color.h
+++ b/kimera_semantics/include/kimera_semantics/color.h
@@ -53,6 +53,8 @@ class SemanticLabel2Color {
   // Make these public if someone wants to access them directly.
   ColorToSemanticLabelMap color_to_semantic_label_;
   SemanticLabelToColorMap semantic_label_to_color_map_;
+
+  size_t number_of_colored_labels;
 };
 
 // Color map from semantic labels to colors.
@@ -66,8 +68,10 @@ inline SemanticLabelToColorMap getRandomSemanticLabelToColorMap() {
   }
   // Make first colours easily distinguishable.
   CHECK_GE(semantic_label_color_map_.size(), 8);
-  CHECK_GE(semantic_label_color_map_.size(), kTotalNumberOfLabels);
+  //We won't use this check, color_map size is numberic limit max anyways
+  //CHECK_GE(semantic_label_color_map_.size(), max_possible_label);
   // TODO(Toni): Check it Matches with default value for SemanticVoxel!
+  //The semantic Labels written here are only meaningful for the Tesse simulation
   semantic_label_color_map_.at(0) = HashableColor::Gray();    // Label unknown
   semantic_label_color_map_.at(1) = HashableColor::Green();   // Label Ceiling
   semantic_label_color_map_.at(2) = HashableColor::Blue();    // Label Chair

--- a/kimera_semantics/include/kimera_semantics/color.h
+++ b/kimera_semantics/include/kimera_semantics/color.h
@@ -54,7 +54,7 @@ class SemanticLabel2Color {
   ColorToSemanticLabelMap color_to_semantic_label_;
   SemanticLabelToColorMap semantic_label_to_color_map_;
 
-  size_t number_of_colored_labels;
+  size_t number_of_colored_labels_;
 };
 
 // Color map from semantic labels to colors.

--- a/kimera_semantics/include/kimera_semantics/common.h
+++ b/kimera_semantics/include/kimera_semantics/common.h
@@ -18,17 +18,16 @@ typedef uint8_t SemanticLabel;
 typedef vxb::AlignedVector<SemanticLabel> SemanticLabels;
 // The size of this array determines how many semantic labels SemanticVoxblox
 // supports.
-// TODO(Toni): parametrize this, although that means it becomes unknown at
-// compile time...
-static constexpr size_t kTotalNumberOfLabels = 21;
+
+//Dynamic size Semantic Probabilities by David R.
 typedef vxb::FloatingPoint SemanticProbability;
-typedef Eigen::Matrix<SemanticProbability, kTotalNumberOfLabels, 1>
+typedef Eigen::Matrix<SemanticProbability, Eigen::Dynamic, 1>
     SemanticProbabilities;
 // A `#Labels X #Labels` Eigen matrix where each `j` column represents the
 // probability of observing label `j` when current label is `i`, where `i`
 // is the row index of the matrix.
 typedef Eigen::
-    Matrix<SemanticProbability, kTotalNumberOfLabels, kTotalNumberOfLabels>
+    Matrix<SemanticProbability, Eigen::Dynamic, Eigen::Dynamic>
         SemanticLikelihoodFunction;
 
 typedef vxb::LongIndexHashMapType<vxb::AlignedVector<size_t>>::type VoxelMap;

--- a/kimera_semantics/include/kimera_semantics/semantic_integrator_base.h
+++ b/kimera_semantics/include/kimera_semantics/semantic_integrator_base.h
@@ -78,7 +78,7 @@ class SemanticIntegratorBase {
 
     //The total number of labels in the segmenation node
     //Used by the confidence matrices
-    size_t total_number_of_layers = 21;
+    size_t total_number_of_labels = 21;
 
     /// How to color the semantic mesh.
     ColorMode color_mode = ColorMode::kSemantic;

--- a/kimera_semantics/include/kimera_semantics/semantic_integrator_base.h
+++ b/kimera_semantics/include/kimera_semantics/semantic_integrator_base.h
@@ -76,6 +76,10 @@ class SemanticIntegratorBase {
     // probability of non-match = 1 - measurement_probability_.
     SemanticProbability semantic_measurement_probability_ = 0.9f;
 
+    //The total number of labels in the segmenation node
+    //Used by the confidence matrices
+    size_t total_number_of_layers = 21;
+
     /// How to color the semantic mesh.
     ColorMode color_mode = ColorMode::kSemantic;
 
@@ -127,6 +131,7 @@ class SemanticIntegratorBase {
   // later by calling updateLayerWithStoredBlocks()
   SemanticVoxel* allocateStorageAndGetSemanticVoxelPtr(
       const vxb::GlobalIndex& global_voxel_idx,
+      size_t total_number_of_labels,
       vxb::Block<SemanticVoxel>::Ptr* last_semantic_block,
       vxb::BlockIndex* last_block_idx);
 

--- a/kimera_semantics/include/kimera_semantics/semantic_integrator_base.h
+++ b/kimera_semantics/include/kimera_semantics/semantic_integrator_base.h
@@ -78,7 +78,7 @@ class SemanticIntegratorBase {
 
     //The total number of labels in the segmenation node
     //Used by the confidence matrices
-    size_t total_number_of_labels = 21;
+    size_t total_number_of_labels_ = 21;
 
     /// How to color the semantic mesh.
     ColorMode color_mode = ColorMode::kSemantic;

--- a/kimera_semantics/include/kimera_semantics/semantic_voxel.h
+++ b/kimera_semantics/include/kimera_semantics/semantic_voxel.h
@@ -16,11 +16,11 @@ namespace kimera {
         // Initialize voxel to unknown label.
         SemanticLabel semantic_label = 0u;
         // Initialize voxel to uniform probability.
-        // Use log odds! So uniform ditribution of 1/total_number_of_layers,
-        // should be std::log(1/total_number_of_layers)
+        // Use log odds! So uniform ditribution of 1/total_number_of_labels,
+        // should be std::log(1/total_number_of_labels)
         size_t total_number_of_layers;
 
-        // SemanticProbabilities::Constant(std::log(1 / total_number_of_layers));
+        // SemanticProbabilities::Constant(std::log(1 / total_number_of_labels));
         SemanticProbabilities semantic_priors;
 
         // Initialize voxel with gray color

--- a/kimera_semantics/include/kimera_semantics/semantic_voxel.h
+++ b/kimera_semantics/include/kimera_semantics/semantic_voxel.h
@@ -11,19 +11,21 @@
 
 namespace kimera {
 
-struct SemanticVoxel {
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  // Initialize voxel to unknown label.
-  SemanticLabel semantic_label = 0u;
-  // Initialize voxel to uniform probability.
-  // Use log odds! So uniform ditribution of 1/kTotalNumberOfLabels,
-  // should be std::log(1/kTotalNumberOfLabels)
-  SemanticProbabilities semantic_priors =
-      // SemanticProbabilities::Constant(std::log(1 / kTotalNumberOfLabels));
-      SemanticProbabilities::Constant(-0.60205999132);
-  // Initialize voxel with gray color
-  // Make sure that all color maps agree on semantic label 0u -> gray
-  HashableColor color = HashableColor::Gray();
-};
+    struct SemanticVoxel {
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        // Initialize voxel to unknown label.
+        SemanticLabel semantic_label = 0u;
+        // Initialize voxel to uniform probability.
+        // Use log odds! So uniform ditribution of 1/total_number_of_layers,
+        // should be std::log(1/total_number_of_layers)
+        size_t total_number_of_layers;
+
+        // SemanticProbabilities::Constant(std::log(1 / total_number_of_layers));
+        SemanticProbabilities semantic_priors;
+
+        // Initialize voxel with gray color
+        // Make sure that all color maps agree on semantic label 0u -> gray
+        HashableColor color = HashableColor::Gray();
+    };
 
 }  // namespace kimera

--- a/kimera_semantics/include/kimera_semantics/semantic_voxel.h
+++ b/kimera_semantics/include/kimera_semantics/semantic_voxel.h
@@ -16,11 +16,11 @@ namespace kimera {
         // Initialize voxel to unknown label.
         SemanticLabel semantic_label = 0u;
         // Initialize voxel to uniform probability.
-        // Use log odds! So uniform ditribution of 1/total_number_of_labels,
-        // should be std::log(1/total_number_of_labels)
-        size_t total_number_of_layers;
+        // Use log odds! So uniform ditribution of 1/total_number_of_labels_,
+        // should be std::log(1/total_number_of_labels_)
+        size_t total_number_of_layers_;
 
-        // SemanticProbabilities::Constant(std::log(1 / total_number_of_labels));
+        // SemanticProbabilities::Constant(std::log(1 / total_number_of_labels_));
         SemanticProbabilities semantic_priors;
 
         // Initialize voxel with gray color

--- a/kimera_semantics/src/color.cpp
+++ b/kimera_semantics/src/color.cpp
@@ -62,7 +62,7 @@ SemanticLabel2Color::SemanticLabel2Color(const std::string& filename)
   // TODO(Toni): remove
   // Assign color 255,255,255 to unknown object 0u
   color_to_semantic_label_[HashableColor::White()] = 0u;
-  number_of_colored_labels = row_number;
+    number_of_colored_labels_ = row_number;
 }
 
 SemanticLabel SemanticLabel2Color::getSemanticLabelFromColor(

--- a/kimera_semantics/src/color.cpp
+++ b/kimera_semantics/src/color.cpp
@@ -62,6 +62,7 @@ SemanticLabel2Color::SemanticLabel2Color(const std::string& filename)
   // TODO(Toni): remove
   // Assign color 255,255,255 to unknown object 0u
   color_to_semantic_label_[HashableColor::White()] = 0u;
+  number_of_colored_labels = row_number;
 }
 
 SemanticLabel SemanticLabel2Color::getSemanticLabelFromColor(

--- a/kimera_semantics/src/semantic_integrator_base.cpp
+++ b/kimera_semantics/src/semantic_integrator_base.cpp
@@ -215,9 +215,6 @@ SemanticVoxel* SemanticIntegratorBase::allocateStorageAndGetSemanticVoxelPtr(
   const vxb::BlockIndex& block_idx = vxb::getBlockIndexFromGlobalVoxelIndex(
       global_voxel_idx, semantic_voxels_per_side_inv_);
 
-  const vxb::VoxelIndex local_voxel_idx = vxb::getLocalFromGlobalVoxelIndex(
-          global_voxel_idx, semantic_voxels_per_side_);
-
   if ((block_idx != *last_block_idx) || (*last_block == nullptr)) {
     *last_block = semantic_layer_->getBlockPtrByIndex(block_idx);
     *last_block_idx = block_idx;
@@ -250,7 +247,7 @@ SemanticVoxel* SemanticIntegratorBase::allocateStorageAndGetSemanticVoxelPtr(
 
       SemanticProbabilities sem_probs;
       sem_probs.resize(total_number_of_labels,1);
-      sem_probs.setConstant(std::log(1.0/float(total_number_of_labels)));
+      sem_probs.setConstant(std::log(1.0 /float(total_number_of_labels)));
 
       for (size_t voxel_index = 0; voxel_index<std::pow(semantic_voxels_per_side_,3); voxel_index++){
           (*last_block)->getVoxelByLinearIndex(voxel_index).total_number_of_layers_ = total_number_of_labels;
@@ -262,6 +259,9 @@ SemanticVoxel* SemanticIntegratorBase::allocateStorageAndGetSemanticVoxelPtr(
 
   // Only used if someone calls the getAllUpdatedBlocks I believe.
   (*last_block)->updated() = true;
+
+  const vxb::VoxelIndex local_voxel_idx = vxb::getLocalFromGlobalVoxelIndex(
+          global_voxel_idx, semantic_voxels_per_side_);
 
   return &((*last_block)->getVoxelByVoxelIndex(local_voxel_idx));
 }
@@ -346,7 +346,7 @@ void SemanticIntegratorBase::normalizeProbabilities(
   } else {
     CHECK_EQ(unnormalized_probs->size(), semantic_config_.total_number_of_labels_);
     static const SemanticProbability kUniformLogProbability =
-        std::log(1 / semantic_config_.total_number_of_labels_);
+        std::log(1.0 / semantic_config_.total_number_of_labels_);
     LOG(WARNING) << "Normalization Factor is " << normalization_factor
                  << ", all values are 0. Normalizing to log(1/n) = "
                  << kUniformLogProbability;

--- a/kimera_semantics/src/semantic_integrator_base.cpp
+++ b/kimera_semantics/src/semantic_integrator_base.cpp
@@ -106,22 +106,22 @@ void SemanticIntegratorBase::setSemanticProbabilities() {
       << "Your probabilities do not make sense... The likelihood of a "
          "label, knowing that we have measured that label, should not be"
          "smaller than the likelihood of seeing another label!";
-  semantic_log_likelihood_.resize(semantic_config_.total_number_of_labels, semantic_config_.total_number_of_labels);
+  semantic_log_likelihood_.resize(semantic_config_.total_number_of_labels_, semantic_config_.total_number_of_labels_);
   semantic_log_likelihood_.setConstant(log_non_match_probability_);
   semantic_log_likelihood_.diagonal() =
       semantic_log_likelihood_.diagonal().setConstant(log_match_probability_);
 
   // TODO(Toni): sanity checks, set as DCHECK_EQ.
   CHECK_NEAR(semantic_log_likelihood_.diagonal().sum(),
-             semantic_config_.total_number_of_labels * log_match_probability_,
+             semantic_config_.total_number_of_labels_ * log_match_probability_,
              10e-2);
 
 
   CHECK_NEAR(
       semantic_log_likelihood_.sum(),
-      semantic_config_.total_number_of_labels * log_match_probability_ +
-      std::pow(semantic_config_.total_number_of_labels, 2) * log_non_match_probability_ -
-      semantic_config_.total_number_of_labels * log_non_match_probability_,
+      semantic_config_.total_number_of_labels_ * log_match_probability_ +
+      std::pow(semantic_config_.total_number_of_labels_, 2) * log_non_match_probability_ -
+      semantic_config_.total_number_of_labels_ * log_non_match_probability_,
       10e-2);
 }
 
@@ -253,7 +253,7 @@ SemanticVoxel* SemanticIntegratorBase::allocateStorageAndGetSemanticVoxelPtr(
       sem_probs.setConstant(std::log(1.0/float(total_number_of_labels)));
 
       for (size_t voxel_index = 0; voxel_index<std::pow(semantic_voxels_per_side_,3); voxel_index++){
-          (*last_block)->getVoxelByLinearIndex(voxel_index).total_number_of_layers = total_number_of_labels;
+          (*last_block)->getVoxelByLinearIndex(voxel_index).total_number_of_layers_ = total_number_of_labels;
           (*last_block)->getVoxelByLinearIndex(voxel_index).semantic_priors = sem_probs;
       }
 
@@ -297,11 +297,11 @@ void SemanticIntegratorBase::updateSemanticVoxelProbabilities(
     const SemanticProbabilities& measurement_frequencies,
     SemanticProbabilities* semantic_prior_probability) const {
   DCHECK(semantic_prior_probability != nullptr);
-  DCHECK_EQ(semantic_prior_probability->size(), semantic_config_.total_number_of_labels);
+  DCHECK_EQ(semantic_prior_probability->size(), semantic_config_.total_number_of_labels_);
   DCHECK_LE((*semantic_prior_probability)[0], 0.0);
   DCHECK(std::isfinite((*semantic_prior_probability)[0]));
   DCHECK(!semantic_prior_probability->hasNaN());
-  DCHECK_EQ(measurement_frequencies.size(), semantic_config_.total_number_of_labels);
+  DCHECK_EQ(measurement_frequencies.size(), semantic_config_.total_number_of_labels_);
   DCHECK_GE(measurement_frequencies.sum(), 1.0)
       << "We should at least have one measurement when calling this "
          "function.";
@@ -344,9 +344,9 @@ void SemanticIntegratorBase::normalizeProbabilities(
   if (normalization_factor != 0.0) {
     unnormalized_probs->normalize();
   } else {
-    CHECK_EQ(unnormalized_probs->size(), semantic_config_.total_number_of_labels);
+    CHECK_EQ(unnormalized_probs->size(), semantic_config_.total_number_of_labels_);
     static const SemanticProbability kUniformLogProbability =
-        std::log(1 / semantic_config_.total_number_of_labels);
+        std::log(1 / semantic_config_.total_number_of_labels_);
     LOG(WARNING) << "Normalization Factor is " << normalization_factor
                  << ", all values are 0. Normalizing to log(1/n) = "
                  << kUniformLogProbability;

--- a/kimera_semantics/src/semantic_tsdf_integrator_fast.cpp
+++ b/kimera_semantics/src/semantic_tsdf_integrator_fast.cpp
@@ -129,10 +129,10 @@ void FastSemanticTsdfIntegrator::integrateSemanticFunction(
       updateTsdfVoxel(origin, point_G, global_voxel_idx, color, weight, voxel);
 
       SemanticVoxel* semantic_voxel = allocateStorageAndGetSemanticVoxelPtr(
-              global_voxel_idx, semantic_config_.total_number_of_labels, &semantic_block, &semantic_block_idx);
+              global_voxel_idx, semantic_config_.total_number_of_labels_, &semantic_block, &semantic_block_idx);
 
       SemanticProbabilities semantic_label_frequencies;
-      semantic_label_frequencies.resize(semantic_config_.total_number_of_labels, 1);
+      semantic_label_frequencies.resize(semantic_config_.total_number_of_labels_, 1);
       semantic_label_frequencies.setZero();
 
       CHECK_LT(semantic_label, semantic_label_frequencies.size());

--- a/kimera_semantics/src/semantic_tsdf_integrator_fast.cpp
+++ b/kimera_semantics/src/semantic_tsdf_integrator_fast.cpp
@@ -128,7 +128,7 @@ void FastSemanticTsdfIntegrator::integrateSemanticFunction(
       updateTsdfVoxel(origin, point_G, global_voxel_idx, color, weight, voxel);
 
       SemanticVoxel* semantic_voxel = allocateStorageAndGetSemanticVoxelPtr(
-          global_voxel_idx, &semantic_block, &semantic_block_idx);
+          global_voxel_idx, semantic_config_.total_number_of_layers, &semantic_block, &semantic_block_idx);
       SemanticProbabilities semantic_label_frequencies =
           SemanticProbabilities::Zero();
       CHECK_LT(semantic_label, semantic_label_frequencies.size());

--- a/kimera_semantics/src/semantic_tsdf_integrator_fast.cpp
+++ b/kimera_semantics/src/semantic_tsdf_integrator_fast.cpp
@@ -41,6 +41,7 @@
 #include <utility>
 
 #include <voxblox/utils/timing.h>
+#include <iostream>
 
 #include "kimera_semantics/color.h"
 
@@ -128,9 +129,12 @@ void FastSemanticTsdfIntegrator::integrateSemanticFunction(
       updateTsdfVoxel(origin, point_G, global_voxel_idx, color, weight, voxel);
 
       SemanticVoxel* semantic_voxel = allocateStorageAndGetSemanticVoxelPtr(
-          global_voxel_idx, semantic_config_.total_number_of_layers, &semantic_block, &semantic_block_idx);
-      SemanticProbabilities semantic_label_frequencies =
-          SemanticProbabilities::Zero();
+              global_voxel_idx, semantic_config_.total_number_of_labels, &semantic_block, &semantic_block_idx);
+
+      SemanticProbabilities semantic_label_frequencies;
+      semantic_label_frequencies.resize(semantic_config_.total_number_of_labels, 1);
+      semantic_label_frequencies.setZero();
+
       CHECK_LT(semantic_label, semantic_label_frequencies.size());
       semantic_label_frequencies[semantic_label] += 1.0f;
       updateSemanticVoxel(global_voxel_idx,

--- a/kimera_semantics/src/semantic_tsdf_integrator_merged.cpp
+++ b/kimera_semantics/src/semantic_tsdf_integrator_merged.cpp
@@ -252,7 +252,7 @@ void MergedSemanticTsdfIntegrator::integrateVoxel(
   // Calculate semantic labels frequencies to encode likelihood function.
   // Prefill with 0 frequency.
   SemanticProbabilities semantic_label_frequencies;
-  semantic_label_frequencies.resize(semantic_config_.total_number_of_labels, 1);
+  semantic_label_frequencies.resize(semantic_config_.total_number_of_labels_, 1);
   semantic_label_frequencies.setZero();
 
   // Loop over all point indices inside current voxel.
@@ -320,7 +320,7 @@ void MergedSemanticTsdfIntegrator::integrateVoxel(
                     merged_weight, voxel);
 
     SemanticVoxel* semantic_voxel =
-        allocateStorageAndGetSemanticVoxelPtr(global_voxel_idx, semantic_config_.total_number_of_labels, &semantic_block, &semantic_block_idx);
+        allocateStorageAndGetSemanticVoxelPtr(global_voxel_idx, semantic_config_.total_number_of_labels_, &semantic_block, &semantic_block_idx);
     updateSemanticVoxel(global_voxel_idx,
                         semantic_label_frequencies,
                         &mutexes_,

--- a/kimera_semantics/src/semantic_tsdf_integrator_merged.cpp
+++ b/kimera_semantics/src/semantic_tsdf_integrator_merged.cpp
@@ -319,7 +319,7 @@ void MergedSemanticTsdfIntegrator::integrateVoxel(
                     merged_weight, voxel);
 
     SemanticVoxel* semantic_voxel =
-        allocateStorageAndGetSemanticVoxelPtr(global_voxel_idx, &semantic_block, &semantic_block_idx);
+        allocateStorageAndGetSemanticVoxelPtr(global_voxel_idx, semantic_config_.total_number_of_layers, &semantic_block, &semantic_block_idx);
     updateSemanticVoxel(global_voxel_idx,
                         semantic_label_frequencies,
                         &mutexes_,

--- a/kimera_semantics/src/semantic_tsdf_integrator_merged.cpp
+++ b/kimera_semantics/src/semantic_tsdf_integrator_merged.cpp
@@ -251,8 +251,9 @@ void MergedSemanticTsdfIntegrator::integrateVoxel(
   vxb::FloatingPoint merged_weight = 0.0f;
   // Calculate semantic labels frequencies to encode likelihood function.
   // Prefill with 0 frequency.
-  SemanticProbabilities semantic_label_frequencies =
-      SemanticProbabilities::Zero();
+  SemanticProbabilities semantic_label_frequencies;
+  semantic_label_frequencies.resize(semantic_config_.total_number_of_labels, 1);
+  semantic_label_frequencies.setZero();
 
   // Loop over all point indices inside current voxel.
   // Generate merged values to propagate to other voxels:
@@ -319,7 +320,7 @@ void MergedSemanticTsdfIntegrator::integrateVoxel(
                     merged_weight, voxel);
 
     SemanticVoxel* semantic_voxel =
-        allocateStorageAndGetSemanticVoxelPtr(global_voxel_idx, semantic_config_.total_number_of_layers, &semantic_block, &semantic_block_idx);
+        allocateStorageAndGetSemanticVoxelPtr(global_voxel_idx, semantic_config_.total_number_of_labels, &semantic_block, &semantic_block_idx);
     updateSemanticVoxel(global_voxel_idx,
                         semantic_label_frequencies,
                         &mutexes_,

--- a/kimera_semantics_ros/launch/kimera_semantics.launch
+++ b/kimera_semantics_ros/launch/kimera_semantics.launch
@@ -125,6 +125,7 @@
 
     <param name="semantic_label_2_color_csv_filepath"
     value="$(find kimera_semantics_ros)/cfg/tesse_multiscene_office1_segmentation_mapping.csv"/>
+    <param name="total_number_of_labels" value="21"/>
 
     <param name="publish_pointclouds"     value="false"/>
     <param name="update_mesh_every_n_sec" value="0.1" />

--- a/kimera_semantics_ros/src/ros_params.cpp
+++ b/kimera_semantics_ros/src/ros_params.cpp
@@ -48,6 +48,12 @@ getSemanticTsdfIntegratorConfigFromRosParam(const ros::NodeHandle& nh_private) {
   semantic_config.semantic_measurement_probability_ =
       static_cast<SemanticProbability>(semantic_measurement_probability);
 
+  // Get the total number of labels of the prediction
+  int total_number_of_layers = semantic_config.total_number_of_layers;
+  nh_private.param("total_number_of_layers",
+                   total_number_of_layers,
+                   total_number_of_layers);
+
   // Get semantic color mode
   std::string color_mode = "color";
   nh_private.param("semantic_color_mode", color_mode, color_mode);

--- a/kimera_semantics_ros/src/ros_params.cpp
+++ b/kimera_semantics_ros/src/ros_params.cpp
@@ -49,10 +49,11 @@ getSemanticTsdfIntegratorConfigFromRosParam(const ros::NodeHandle& nh_private) {
       static_cast<SemanticProbability>(semantic_measurement_probability);
 
   // Get the total number of labels of the prediction
-  int total_number_of_layers = semantic_config.total_number_of_layers;
-  nh_private.param("total_number_of_layers",
-                   total_number_of_layers,
-                   total_number_of_layers);
+  int total_number_of_labels = static_cast<int>(semantic_config.total_number_of_labels);
+  nh_private.param("total_number_of_labels",
+                   total_number_of_labels,
+                   total_number_of_labels);
+  semantic_config.total_number_of_labels = static_cast<size_t>(total_number_of_labels);
 
   // Get semantic color mode
   std::string color_mode = "color";

--- a/kimera_semantics_ros/src/ros_params.cpp
+++ b/kimera_semantics_ros/src/ros_params.cpp
@@ -49,11 +49,11 @@ getSemanticTsdfIntegratorConfigFromRosParam(const ros::NodeHandle& nh_private) {
       static_cast<SemanticProbability>(semantic_measurement_probability);
 
   // Get the total number of labels of the prediction
-  int total_number_of_labels = static_cast<int>(semantic_config.total_number_of_labels);
+  int total_number_of_labels = static_cast<int>(semantic_config.total_number_of_labels_);
   nh_private.param("total_number_of_labels",
                    total_number_of_labels,
                    total_number_of_labels);
-  semantic_config.total_number_of_labels = static_cast<size_t>(total_number_of_labels);
+  semantic_config.total_number_of_labels_ = static_cast<size_t>(total_number_of_labels);
 
   // Get semantic color mode
   std::string color_mode = "color";


### PR DESCRIPTION
Addressing my own issue #55, using dynamic sized semantic prior matrices and initialization in runtime. 
Reading number of labels from the launch file as a rosparam. 

I believe the biggest concern could be the performance issue, for this here is a comparison of timings on the provided simulated semantic rosbag file. 

**With static  labels**
```

[ INFO] [1612796164.603515954, 60.342383269]: Layer memory: 16679159
[ INFO] [1612796164.603544030, 60.342383269]: Updating mesh.
[ INFO] [1612796164.620216339, 60.367825609]: Updating mesh.78.072170               
[ INFO] [1612796164.639555585, 60.414999999]: Integrating a pointcloud with 345600 points.
[ INFO] [1612796164.711103207, 60.544733472]: Finished integrating in 0.071499 seconds, have 339 blocks.
[ INFO] [1612796164.711173976, 60.544733472]: Timings: 
SM Timing
-----------
inserting_missed_blocks	     59	00.000255	(00.000004 +- 00.000003)	[00.000001,00.000094]
integrate/fast         	     59	05.165177	(00.087545 +- 00.009905)	[00.065052,00.165955]
mesh/publish           	    108	00.286112	(00.002649 +- 00.003277)	[00.000005,00.009061]
mesh/update            	    108	00.578068	(00.005352 +- 00.004863)	[00.000168,00.014176]
ptcloud_preprocess     	     59	00.590554	(00.010009 +- 00.004439)	[00.008309,00.034639]
remove_distant_blocks  	     59	00.000979	(00.000017 +- 00.000005)	[00.000006,00.000031]
```


**With dynamic labels**

```
[ INFO] [1612795707.691550318, 59.152784140]: Layer memory: 16629958
[ INFO] [1612795707.691564063, 59.152784140]: Updating mesh.
[ INFO] [1612795707.707433151, 59.172894621]: Updating mesh.78.072170               
[ INFO] [1612795707.728666358, 59.233487071]: Updating mesh.78.072170               
[ INFO] [1612795707.775409911, 59.323973636]: Integrating a pointcloud with 345600 points.
[ INFO] [1612795707.861115732, 59.483209653]: Finished integrating in 0.085651 seconds, have 339 blocks.
[ INFO] [1612795707.861209100, 59.483209653]: Timings: 
SM Timing
-----------
inserting_missed_blocks	     54	00.000232	(00.000004 +- 00.000003)	[00.000001,00.000066]
integrate/fast         	     54	05.019893	(00.092961 +- 00.010746)	[00.070486,00.244003]
mesh/publish           	     98	00.245623	(00.002506 +- 00.003167)	[00.000007,00.009175]
mesh/update            	     98	00.499049	(00.005092 +- 00.005313)	[00.000144,00.018225]
ptcloud_preprocess     	     54	00.486605	(00.009011 +- 00.000462)	[00.008290,00.018598]
remove_distant_blocks  	     54	00.000844	(00.000016 +- 00.000005)	[00.000002,00.000034]
```