### PR TITLE
Add world_frame argument to launch files for customization

### DIFF
--- a/kimera_semantics_ros/launch/kimera_semantics.launch
+++ b/kimera_semantics_ros/launch/kimera_semantics.launch
@@ -10,6 +10,7 @@
    - 2. Or, if you want to use simulator's ground-truth: `left_cam`
   -->
   <arg name="sensor_frame" default="left_cam"/>
+  <arg name="world_frame"  default="world"/>
 
   <!-- If you want to play directly from a rosbag -->
   <arg name="play_bag" default="false"/>
@@ -105,6 +106,7 @@
     <param name="use_freespace_pointcloud"  value="$(arg use_freespace_pointcloud)" />
     <remap from="freespace_pointcloud"      to="$(arg freespace_pointcloud)"/>
 
+    <param name="world_frame"              value="$(arg world_frame)"/>
     <param name="sensor_frame"              value="$(arg sensor_frame)"/>
     <param name="use_tf_transforms"         value="true" />
 

--- a/kimera_semantics_ros/launch/kimera_semantics_euroc.launch
+++ b/kimera_semantics_ros/launch/kimera_semantics_euroc.launch
@@ -6,6 +6,7 @@
 
   <!-- We use VIO's estimated base_link: `left_cam_base_link` -->
   <arg name="sensor_frame" default="cam0"/>
+  <arg name="world_frame"  default="world"/>
 
   <!-- If you want to play directly from a rosbag -->
   <arg name="play_bag" default="false"/>


### PR DESCRIPTION
Add the `world_frame` argument so as to customize the `world_frame_id` for showing in rviz and figure out this [problem](https://github.com/MIT-SPARK/Kimera-VIO-ROS/issues/46#issuecomment-2518022324)